### PR TITLE
FL-26464 Don't export the libstdc++ symbols on Linux

### DIFF
--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -256,13 +256,14 @@ if(OS_LINUX)
   # USING_JAVA          = Add the USING_JAVA define.
   target_compile_definitions(${JCEF_TARGET} PRIVATE "USING_JAVA")
 
-  # -fvisibility=default  = Give default visibility to declarations that are not explicitly marked as visible.
-  #                         Necessary so that JNI symbols are properly exported when building with GCC.
-  #                         Related discussion: http://mail.openjdk.java.net/pipermail/core-libs-dev/2013-February/014446.html
-  #                         Test symbol export with: nm -D --defined-only libjcef.so | grep Java
-  set_target_properties(${JCEF_TARGET} PROPERTIES
-    COMPILE_FLAGS -fvisibility=default
+  # Export only JNI symbols (especially important when statically linking other libraries, e.g., libstdc++)
+  # Test symbol export with: nm -D --defined-only libjcef.so
+  set(JCEF_VERSION_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/jcef_exports.map)
+  target_link_options(${JCEF_TARGET} PRIVATE
+    -Wl,--version-script,${JCEF_VERSION_SCRIPT}
+    -Wl,--no-undefined-version
     )
+  set_target_properties(${JCEF_TARGET} PROPERTIES LINK_DEPENDS ${JCEF_VERSION_SCRIPT})
 
   # Set rpath so that libraries can be placed next to the library.
   set_target_properties(${JCEF_TARGET} PROPERTIES INSTALL_RPATH "$ORIGIN")

--- a/native/jcef_exports.map
+++ b/native/jcef_exports.map
@@ -1,0 +1,6 @@
+{
+    global:
+        Java_org_cef_*;
+    local:
+        *;
+};

--- a/remote/CMakeLists.txt
+++ b/remote/CMakeLists.txt
@@ -395,4 +395,14 @@ add_library(shared_mem_helper SHARED ${shared_mem_helper_SOURCES})
 target_include_directories(shared_mem_helper PUBLIC ${JNI_INCLUDE_DIRS})
 if (OS_LINUX)
     target_link_libraries(shared_mem_helper rt)
+
+    # Export only JNI symbols (especially important when statically linking other libraries, e.g., libstdc++)
+    # Test symbol export with: nm -D --defined-only libshared_mem_helper.so
+    set(VERSION_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/shared_mem_helper_exports.map)
+    target_link_options(shared_mem_helper PRIVATE
+        -Wl,--version-script,${VERSION_SCRIPT}
+        -Wl,--no-undefined-version
+        )
+    set_target_properties(shared_mem_helper PROPERTIES LINK_DEPENDS ${VERSION_SCRIPT})
+
 endif ()

--- a/remote/shared_mem_helper_exports.map
+++ b/remote/shared_mem_helper_exports.map
@@ -1,0 +1,6 @@
+{
+    global:
+        Java_com_jetbrains_cef_*;
+    local:
+        *;
+};


### PR DESCRIPTION
We're statically linking libstdc++, but didn't control the symbol visibility, which causes crashes for apps dynamically linking libstdc++.

Now export only the JNI symbols from the C++ libraries (`libjcef` and `libshared_mem_helper`).

See https://yrom.net/blog/2023/04/19/how-to-explicitly-control-exported-symbols-of-dyamic-shared-libraries/