### PR TITLE
ant: Use JavaVersion condition over regex for Java 17 checks

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -39,13 +39,13 @@
   <condition property="jvm.opts"
              value="--module-path=${toString:module.path} --add-modules jogl.all,gluegen.rt --add-exports jogl.all/com.jogamp.nativewindow=jcef --add-exports jogl.all/com.jogamp.opengl.awt=jcef --add-exports jogl.all/com.jogamp.opengl.util=jcef --add-exports jogl.all/com.jogamp.opengl=jcef --add-exports java.desktop/sun.awt=jcef --add-exports java.desktop/java.awt.peer=jcef --add-exports java.desktop/sun.lwawt.macosx=jcef --add-exports java.desktop/sun.lwawt=jcef"
              else="">
-    <matches pattern="17*.*" string="${java.version}"/>
+    <javaversion atleast="17"/>
   </condition>
 
   <condition property="include.module-info.class"
              value="module-info.class"
              else="">
-    <matches pattern="17*.*" string="${java.version}"/>
+    <javaversion atleast="17"/>
   </condition>
 
   <condition property="exclude.module-info.java"


### PR DESCRIPTION
This fixes the version check for adding required modules to the JVM arguments.

The current check for the condition is a regex match, with it being `17*.*`, which, effectively, matches every version with a 1 in any position.
The regex fails on versions past Java 20 that doesn't contain a 1, such as Java 25.0.2

This pushes the minimum ant required version to 1.10.2, but with 1.9.x being EOL, it shouldn't pose issues

Fixes #40 