### PR TITLE
CefLog: Support subclassing

### DIFF
--- a/java/org/cef/misc/CefLog.java
+++ b/java/org/cef/misc/CefLog.java
@@ -18,9 +18,9 @@ public class CefLog {
     private static volatile boolean isInitialized = false;
     private static final SimpleDateFormat ourTimeFormat = new SimpleDateFormat("mm:ss:SSS");
 
-    private String myFilePath;
-    private PrintStream myPrintStream;
-    private CefSettings.LogSeverity mySeverity;
+    protected String myFilePath;
+    protected PrintStream myPrintStream;
+    protected CefSettings.LogSeverity mySeverity;
 
     public static void initVerbose() {
         String log_file = Utils.getString("jcef.log.path");
@@ -86,7 +86,26 @@ public class CefLog {
         INSTANCE = new CefLog(useStdOut ? System.out : System.err, severity);
     }
 
-    private CefLog(PrintStream ps, CefSettings.LogSeverity log_severity) {
+    public static void init(CefLog logger) {
+        init(logger, false);
+    }
+
+    public static void init(CefLog logger, boolean forceReinit) {
+        if (logger == null) throw new IllegalArgumentException("logger must not be null");
+        if (isInitialized) {
+            if (!forceReinit) {
+                if (INSTANCE != null)
+                    Log(CefSettings.LogSeverity.LOGSEVERITY_VERBOSE,"CefLog is already initialized (severity=%s, path='%s'), new instance will be ignored.",
+                            INSTANCE.mySeverity, INSTANCE.myFilePath);
+                return;
+            }
+            System.out.println("Reinitialize CefLog.\n");
+        }
+        INSTANCE = logger;
+        isInitialized = true;
+    }
+
+    protected CefLog(PrintStream ps, CefSettings.LogSeverity log_severity) {
         myPrintStream = ps;
         mySeverity = log_severity;
     }
@@ -146,6 +165,7 @@ public class CefLog {
     static public boolean IsDebugEnabled() { return INSTANCE != null ? INSTANCE.isDebugEnabled() : false; }
     static public String GetFilePath() { return INSTANCE != null ? INSTANCE.myFilePath : null; }
     static public CefSettings.LogSeverity GetLogLevel() { return INSTANCE != null ? INSTANCE.mySeverity : null; }
+    static public CefLog GetInstance() { return INSTANCE; }
 
     static public void Log(CefSettings.LogSeverity log_severity, String msg, Object... args) {
         if (msg == null || INSTANCE == null)

--- a/java_tests/tests/basic/BasicJcefTest.java
+++ b/java_tests/tests/basic/BasicJcefTest.java
@@ -47,8 +47,32 @@ public class BasicJcefTest {
     private static final long WAIT_TIMEOUT_MS = Utils.getInteger("WAIT_SERVER_TIMEOUT_MS", 30000); // 30 sec
     private static final String TCP_KEY = "CEF_SERVER_USE_TCP";
 
+    private static class TestLog extends CefLog {
+        public boolean errorWasCalled;
+
+        public TestLog(String log_file) {
+            super(createStream(log_file), CefSettings.LogSeverity.LOGSEVERITY_VERBOSE);
+            myFilePath = log_file;
+        }
+
+        private static PrintStream createStream(String log_file) {
+            if (log_file == null) return System.err;
+            try {
+                return new PrintStream(new FileOutputStream(log_file, true), true);
+            } catch (FileNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void log(CefSettings.LogSeverity log_severity, String msg, Object... args) {
+            super.log(log_severity, msg, args);
+            if (log_severity.compareTo(CefSettings.LogSeverity.LOGSEVERITY_ERROR) >= 0) errorWasCalled = true;
+        }
+    }
+
     static {
-        CefLog.init(Utils.getString("JCEF_TESTS_LOG_FILE"), CefSettings.LogSeverity.LOGSEVERITY_VERBOSE);
+        CefLog.init(new TestLog(Utils.getString("JCEF_TESTS_LOG_FILE")));
     }
 
     @Test
@@ -577,6 +601,17 @@ public class BasicJcefTest {
                 System.setProperty(TCP_KEY, isTcpPrev);
             else
                 System.clearProperty(TCP_KEY);
+        }
+    }
+
+    @Test
+    @Order(4)
+    void testLogSubclass() {
+        TestLog logger = (TestLog) CefLog.GetInstance();
+        logger.errorWasCalled = false;
+        CefLog.Error("test");
+        if (!logger.errorWasCalled) {
+            throw new AssertionError("Method not called");
         }
     }
 


### PR DESCRIPTION
Until a proper logging system like log4j is supported, allow subclassing of the logger to allow the library consumer to implement this themselves